### PR TITLE
APIアクセスにスロットリングを実装

### DIFF
--- a/bgslogviewer.go
+++ b/bgslogviewer.go
@@ -96,7 +96,12 @@ func statPage(c *gin.Context) {
 		return
 	}
 
-	if stat == apiCaller.Invalid {
+	switch stat {
+	case apiCaller.Timeout:
+		c.String(503, "Too many access")
+		pf.End(503)
+		return
+	case apiCaller.Invalid:
 		c.String(404, "Invalid request")
 		pf.End(404)
 		return

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ bgslogviewer:
   links:
     - redis
   environment:
-    BLV_PROFILE: "true"
+    BLV_PROFILE: "false"
     REDIS_HOST: "redis"
     REDIS_PORT: "6379"
 redis:


### PR DESCRIPTION
スロットリングを忘れていて、同時に複数の異なるアクセスが来たときにEDSMのAPIアクセス制限をオーバーする可能性があったので修正。